### PR TITLE
fix RegistList of UnregisterAllSuccess with empty array

### DIFF
--- a/reference/kabu_STATION_API.yaml
+++ b/reference/kabu_STATION_API.yaml
@@ -2868,8 +2868,8 @@ definitions:
     type: "object"
     properties:
       RegistList:
-        description: "現在登録されている銘柄のリスト<br>※銘柄登録解除が正常に行われれば、空リストを返します。<br>　登録解除でエラー等が発生した場合、現在登録されている銘柄のリストを返します"
-        type: "object"
+        description: "現在登録されている銘柄のリスト<br>※常に空リストを返します。"
+        type: "array"
         example: []
   SymbolSuccess:
     type: "object"


### PR DESCRIPTION
[【不具合】\`UnregisterAllSuccess\` の \`RegistList\` が型定義できていなさそうなので調整したい · Issue \#219 · kabucom/kabusapi](https://github.com/kabucom/kabusapi/issues/219)

の対応で

[define RegistList for responses of RegistSuccess and UnregisterAllSuccess by hori\-ryota · Pull Request \#220 · kabucom/kabusapi](https://github.com/kabucom/kabusapi/pull/220)

の別解です。

https://github.com/kabucom/kabusapi/issues/219#issuecomment-761006922

でご回答いただいた

> UnregisterAllSuccessは、銘柄全クリアをした結果になるので、空レスポンスになります。

が常に空レスポンスが返ってくる（エラー時もエラー用の `ErrorResponse` が返ってくる）と解釈し、 `登録解除でエラー等が発生した場合、現在登録されている銘柄のリストを返します` は誤記と解釈した場合はこちらになるかと思います。

一方、この場合は RegistListも不要なので

```
  UnregisterAllSuccess:
    type: "object"
    properties: {}
```

に仕様変更するのが妥当かもしれません。

ただ、UnregisterAllSuccess（ `PUT /unregister/all` ）は仕様変更の互換を考えるとRegistListが返るものとし

[define RegistList for responses of RegistSuccess and UnregisterAllSuccess by hori\-ryota · Pull Request \#220 · kabucom/kabusapi](https://github.com/kabucom/kabusapi/pull/220)

の対応のほうが筋が良さそうに思いました。